### PR TITLE
typo: wrong name of serial variable

### DIFF
--- a/CIAJeepdoors_1.3/CIAJeepDoors.py
+++ b/CIAJeepdoors_1.3/CIAJeepDoors.py
@@ -254,7 +254,7 @@ def main():
     print('++++++++++++++++++++++++++++++++++++++')
     print('Please only use Android DJI Fly, the iOS version will reset the privacy bits.')
     print('++++++++++++++++++++++++++++++++++++++')
-    set.close()
+    ser.close()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Version 1.3 of script ends with next error:
AttributeError: type object 'set' has no attribute 'close'
-----
So, this patch fixes this issue.